### PR TITLE
Update .travis.yml 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ script:
 deploy:
   provider: pages
   skip-cleanup: true
-  local-dir: build
+  local-dir: www/build
   repo: MindongLab/foochow-idioms-web
   github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
   keep-history: true


### PR DESCRIPTION
- Travis CI failed to deploy because `/build` directory is not found
```
cd /tmp/d20180501-4868-ecxu91/work
rsync: change_dir "/home/travis/build/MindongLab/foochow-idioms/build" failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1183) [sender=3.1.0]
Could not copy /home/travis/build/MindongLab/foochow-idioms/build.
```

No idea why it worked before.